### PR TITLE
Fixed require syntax for sdoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'turbolinks', '1.1.1'
 gem 'jbuilder', '1.0.2'
 
 group :doc do
-  gem 'sdoc', '0.3.20', require: false
+  gem 'sdoc', '0.3.20', :require => false
 end
 
 group :production do


### PR DESCRIPTION
Syntax for require statement cause Bundler to fail setup. Updated to match known syntax.
